### PR TITLE
[MOB-14615] - Migrate to AEPAssurance 3.0 on swift sampleApp

### DIFF
--- a/Swift/AEPSampleApp/AppDelegate.swift
+++ b/Swift/AEPSampleApp/AppDelegate.swift
@@ -58,7 +58,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                           //step-extension-end
                           , UserProfile.self
                           // step-assurance-start
-                          , AEPAssurance.self
+                          , Assurance.self
                           // step-assurance-end
                           , Messaging.self
                         ]

--- a/Swift/AEPSampleApp/AssuranceView.swift
+++ b/Swift/AEPSampleApp/AssuranceView.swift
@@ -25,7 +25,7 @@ struct AssuranceView: View {
                     // step-assurance-start
                     // replace the url with the valid one generated on Assurance UI
                     if let url = URL(string: self.assuranceSessionUrl) {
-                        AEPAssurance.startSession(url)
+                        Assurance.startSession(url: url)
                     }
                     // step-assurance-end
                 }){

--- a/Swift/AEPSampleApp/SceneDelegate.swift
+++ b/Swift/AEPSampleApp/SceneDelegate.swift
@@ -28,6 +28,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        
+        // Called when the app launches with the deep link
+        if let deepLinkURL = connectionOptions.urlContexts.first?.url {
+            Assurance.startSession(url: deepLinkURL)
+        }
+
+        
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(frame: windowScene.coordinateSpace.bounds)
         window?.windowScene = windowScene
@@ -67,7 +74,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         // step-assurance-start
         guard let urlContexts = URLContexts.first else { return }
-        AEPAssurance.startSession(urlContexts.url)
+        Assurance.startSession(url: urlContexts.url)
         // step-assurance-end
     }
 }

--- a/Swift/Podfile
+++ b/Swift/Podfile
@@ -27,7 +27,6 @@ target 'AEPSampleApp' do
   # step-edge-end
 
   # step-assurance-start
-  pod 'ACPCore', :git => 'https://github.com/adobe/aepsdk-compatibility-ios.git', :branch => 'main'
   pod 'AEPAssurance'
   # step-assurance-end
   

--- a/Swift/Podfile.lock
+++ b/Swift/Podfile.lock
@@ -1,31 +1,22 @@
 PODS:
-  - ACPCore (2.9.9):
-    - AEPCore
-    - AEPIdentity
-    - AEPLifecycle
-    - AEPRulesEngine
-    - AEPServices
-    - AEPSignal
-  - AEPAssurance (1.1.1):
-    - ACPCore (>= 2.9.0)
-    - AEPAssurance/xcframeworks (= 1.1.1)
-  - AEPAssurance/xcframeworks (1.1.1):
-    - ACPCore (>= 2.9.0)
-  - AEPCore (3.1.3):
+  - AEPAssurance (3.0.0):
+    - AEPCore (>= 3.1.0)
+    - AEPServices (>= 3.1.0)
+  - AEPCore (3.2.1):
     - AEPRulesEngine (= 1.0.1)
-    - AEPServices (= 3.1.3)
-  - AEPEdge (1.1.0):
+    - AEPServices (= 3.2.1)
+  - AEPEdge (1.1.1):
     - AEPCore (>= 3.1.1)
     - AEPEdgeIdentity
   - AEPEdgeConsent (1.0.0):
     - AEPCore (>= 3.1.0)
   - AEPEdgeIdentity (1.0.0):
     - AEPCore (>= 3.1.1)
-  - AEPIdentity (3.1.3):
-    - AEPCore (= 3.1.3)
-  - AEPLifecycle (3.1.3):
-    - AEPCore (= 3.1.3)
-  - AEPMessaging (1.0.0-beta-1):
+  - AEPIdentity (3.2.1):
+    - AEPCore (= 3.2.1)
+  - AEPLifecycle (3.2.1):
+    - AEPCore (= 3.2.1)
+  - AEPMessaging (1.0.0):
     - AEPCore
     - AEPEdge (>= 1.1.0)
     - AEPEdgeIdentity (>= 1.0.0)
@@ -33,14 +24,13 @@ PODS:
   - AEPRulesEngine (1.0.1)
   - AEPSampleExtensionSwift (0.0.1):
     - AEPCore (~> 3.0)
-  - AEPServices (3.1.3)
-  - AEPSignal (3.1.3):
-    - AEPCore (= 3.1.3)
+  - AEPServices (3.2.1)
+  - AEPSignal (3.2.1):
+    - AEPCore (= 3.2.1)
   - AEPUserProfile (3.0.0):
     - AEPCore
 
 DEPENDENCIES:
-  - ACPCore (from `https://github.com/adobe/aepsdk-compatibility-ios.git`, branch `main`)
   - AEPAssurance
   - AEPCore
   - AEPEdge
@@ -70,9 +60,6 @@ SPEC REPOS:
     - AEPUserProfile
 
 EXTERNAL SOURCES:
-  ACPCore:
-    :branch: main
-    :git: https://github.com/adobe/aepsdk-compatibility-ios.git
   AEPMessaging:
     :branch: main
     :git: https://github.com/adobe/aepsdk-messaging-ios.git
@@ -81,32 +68,28 @@ EXTERNAL SOURCES:
     :git: https://github.com/adobe/aepsdk-sample-extension-ios.git
 
 CHECKOUT OPTIONS:
-  ACPCore:
-    :commit: c43675de0c97ee76fd51b005e8c9cdc7515e4a78
-    :git: https://github.com/adobe/aepsdk-compatibility-ios.git
   AEPMessaging:
-    :commit: 2cbb4c12d33bb611b0ef5df09c70b8e4760d99c0
+    :commit: af52b750ee9db7ec874aaeba27bad9b37b2183e3
     :git: https://github.com/adobe/aepsdk-messaging-ios.git
   AEPSampleExtensionSwift:
     :commit: 23fe9522505774eb602cbfcc6ef4cb9fc4d9db21
     :git: https://github.com/adobe/aepsdk-sample-extension-ios.git
 
 SPEC CHECKSUMS:
-  ACPCore: 67e4b855bf16cfb6a63024a4ddb73d15c0fd30e5
-  AEPAssurance: b62fc1be16efbc8d137b945b29da7e5ec7c7965a
-  AEPCore: 6ec14ec9b1ff45999ea53be112aba85522ad00c4
-  AEPEdge: 818ca6ea6ac1a9e16a876036c78908996033599f
+  AEPAssurance: 18068627111e366a851dc2166239f22b665101bd
+  AEPCore: 1c7a38cbd0e31c013bd4ca388a0a1cb03e9e0432
+  AEPEdge: ff0cf67e25c342a7a9d48e9a77e9485869dad043
   AEPEdgeConsent: dd46002b0c4bf55443f5441990e799248975713e
   AEPEdgeIdentity: 40d312b4434b710a46c1738ab2a221dda4cfd67e
-  AEPIdentity: 49e6c742238be0f77d5ae8928c13acfd1d8bec3c
-  AEPLifecycle: 9ed7ceabd98cc5c94b13c3b085c9f1eef2c714fe
-  AEPMessaging: e013381ed392007ab60483ef0a897737381af484
+  AEPIdentity: 18039f69f3f28f29321bb792d8d457f56fca7cde
+  AEPLifecycle: 4caf755b1a0aab0082078f07bd02205f75a381f6
+  AEPMessaging: 661cc08435254f3c9cc0899785c20a7952952e95
   AEPRulesEngine: 5075ed294026a12e37bd26fe260f74604d205354
   AEPSampleExtensionSwift: 57f8b73affbf831b274257811a2102805c498538
-  AEPServices: e032bfacfcb31f3a583b2aa1e87df5d427cca95d
-  AEPSignal: c0619814fbf50dbb1dde4e79141d528aa2606e9e
+  AEPServices: dd322612b8dda359877d6006c98887267f296e06
+  AEPSignal: 3ed4fed12f0400f44fbf3a9af481c3c8b52ad12c
   AEPUserProfile: d8702b2e3fc321febdc3854208db9bb1ad3b61c8
 
-PODFILE CHECKSUM: 46c60c418f01fa7c1c0a36ffd8be1b983fc8ce30
+PODFILE CHECKSUM: 4fd738829bbf2fbf215f27757f73dd974bebed09
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
The pull request demonstrates migration to AEPAssurance 3.0 on Swift application.

## Description

- Update AEPAssurance Pods to 3.x
- Refactor the AEPAssurance API's.

## How Has This Been Tested?

The sample app builds and connects successfully to an assurance session.

## Screenshots (if appropriate):

<img width="250" alt="Screen Shot 2021-06-27 at 9 13 51 PM" src="https://user-images.githubusercontent.com/8909148/123670750-6581e080-d7f2-11eb-9048-985e2e623e59.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)