### PR TITLE
Update Edge Identity View to demonstrate new ad ID and IDFA capabilities

### DIFF
--- a/Swift/AEPSampleApp.xcodeproj/project.pbxproj
+++ b/Swift/AEPSampleApp.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		3FEEA0E12523DBB5007EC317 /* CoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEEA0E02523DBB4007EC317 /* CoreView.swift */; };
 		3FEEA0E32524DA4A007EC317 /* ButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEEA0E22524DA4A007EC317 /* ButtonStyle.swift */; };
 		411747AC27ACB1DE0025F55A /* Adobe_Experience_Platform_logo_256px.png in Resources */ = {isa = PBXBuildFile; fileRef = 411747AB27ACB1DE0025F55A /* Adobe_Experience_Platform_logo_256px.png */; };
+		4CEC1FD227D71540000724F8 /* AppTrackingTransparency.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4CEC1FD127D71540000724F8 /* AppTrackingTransparency.framework */; };
 		782B982124D9BA89009C5902 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782B982024D9BA89009C5902 /* AppDelegate.swift */; };
 		782B982324D9BA89009C5902 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782B982224D9BA89009C5902 /* SceneDelegate.swift */; };
 		782B982A24D9BA8C009C5902 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 782B982924D9BA8C009C5902 /* Assets.xcassets */; };
@@ -48,6 +49,7 @@
 		3FEEA0E02523DBB4007EC317 /* CoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreView.swift; sourceTree = "<group>"; };
 		3FEEA0E22524DA4A007EC317 /* ButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonStyle.swift; sourceTree = "<group>"; };
 		411747AB27ACB1DE0025F55A /* Adobe_Experience_Platform_logo_256px.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Adobe_Experience_Platform_logo_256px.png; path = ../../Resources/Icons/Adobe_Experience_Platform_logo_256px.png; sourceTree = "<group>"; };
+		4CEC1FD127D71540000724F8 /* AppTrackingTransparency.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppTrackingTransparency.framework; path = System/Library/Frameworks/AppTrackingTransparency.framework; sourceTree = SDKROOT; };
 		782B981D24D9BA89009C5902 /* AEPSampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AEPSampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		782B982024D9BA89009C5902 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		782B982224D9BA89009C5902 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -82,6 +84,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4CEC1FD227D71540000724F8 /* AppTrackingTransparency.framework in Frameworks */,
 				E85CDFD29B450F16196D4F79 /* Pods_AEPSampleApp.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -133,6 +136,7 @@
 		AD49D2DD097EA82A906007CE /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				4CEC1FD127D71540000724F8 /* AppTrackingTransparency.framework */,
 				D94C7204C94E9F5D9F472F31 /* Pods_AEPSampleApp.framework */,
 			);
 			name = Frameworks;

--- a/Swift/AEPSampleApp/EdgeIdentityView.swift
+++ b/Swift/AEPSampleApp/EdgeIdentityView.swift
@@ -7,13 +7,95 @@
  it.
  */
 
-import Foundation
+import AdSupport
+import AEPCore
 import AEPEdgeIdentity
+import AppTrackingTransparency
+import Foundation
 import SwiftUI
 
 struct EdgeIdentityView: View {
     @State var currentEcid = ""
     @State var currentIdentityMap: IdentityMap?
+    @State var adID: UUID?
+    @State var adIdText: String = ""
+    @State var trackingAuthorizationResultText: String = ""
+    
+    /// Provides the `advertisingIdentifier` for the given environment, assuming tracking authorization is provided
+    ///
+    /// Simulators will never provide a valid UUID, regardless of authorization; use the set ad ID flow to test a specific ad ID.
+    func getAdvertisingIdentifierForEnvironment() -> UUID {
+        #if targetEnvironment(simulator)
+        print("""
+            Simulator environment detected. Please note that simulators cannot retrieve valid advertising identifier
+            from the ASIdentifierManager (as specified by Apple); an all-zeros UUID will be retrieved even if
+            authorization is provided. If you want to use a specific ad ID, you can use the set ad ID flow.
+            """)
+        #endif
+        print("Advertising identifier: \(ASIdentifierManager.shared().advertisingIdentifier)")
+        return ASIdentifierManager.shared().advertisingIdentifier
+    }
+    
+    /// Requests tracking authorization from the user; prompt will only be shown once per app install, as per Apple rules
+    ///
+    /// It is possible to change tracking permissions at the Settings app level. Any change in tracking permissions will terminate the app.
+    /// It is also possible for system-wide tracking to be off but individual per-app permissions granted.
+    /// If "Allow Apps to Request to Track" at the system level was on and is turned off, a system prompt appears asking if previously provided individual per-app tracking permissions should be kept as-is or all turned off
+    func requestTrackingAuthorization() {
+        // ATTrackingManager only available in iOS 14+
+        // Requires Xcode 12 and AppTrackingTransparency framework
+        if #available(iOS 14, *) {
+            print("Calling requestTrackingAuthorization. Dialog will only be shown once per app install.")
+            ATTrackingManager.requestTrackingAuthorization { status in
+                switch status {
+                // Tracking authorization dialog was shown and authorization given
+                case .authorized:
+                    trackingAuthorizationResultText = "Authorized"
+                    // IDFA now accessible
+                    self.adID = getAdvertisingIdentifierForEnvironment()
+                    
+                    // Set IDFA using Core API, which will be routed to Edge Identity extension.
+                    // Note that this will automatically update ad ID consent (consent event dispatched)
+                    // to "y" but only if the ad ID is not nil, all-zeros, or ""; in the case of the simulator it will be all-zeros.
+                    // Set the ad ID manually after getting authorization to get consent updated properly
+                    MobileCore.setAdvertisingIdentifier(self.adID?.uuidString)
+                    
+                // Tracking authorization dialog was shown and permission is denied
+                case .denied:
+                    trackingAuthorizationResultText = "Denied"
+                    MobileCore.setAdvertisingIdentifier("")
+                // Tracking authorization dialog has not been shown
+                case .notDetermined:
+                    trackingAuthorizationResultText = "Not Determined"
+                // Tracking authorization dialog is not allowed to be shown
+                case .restricted:
+                    trackingAuthorizationResultText = "Restricted"
+                @unknown default:
+                    trackingAuthorizationResultText = "Unknown"
+                }
+                print("Request tracking authorization status is '\(trackingAuthorizationResultText)'.")
+            }
+        } else {
+            // ASIdentifierManager used for iOS <= 13
+            print("""
+                  iOS version <= 13 detected. ATTrackingManager's requestTrackingAuthorization is not available; using ASIdentifierManager and getting IDFA directly.
+                  ASIdentifierManager.shared().isAdvertisingTrackingEnabled: \(ASIdentifierManager.shared().isAdvertisingTrackingEnabled)
+                  Advertising identifier: \(getAdvertisingIdentifierForEnvironment())
+                  """)
+            if ASIdentifierManager.shared().isAdvertisingTrackingEnabled {
+                self.adID = getAdvertisingIdentifierForEnvironment()
+                trackingAuthorizationResultText = "Tracking enabled"
+                
+                MobileCore.setAdvertisingIdentifier(self.adID?.uuidString)
+                
+            } else {
+                trackingAuthorizationResultText = "Tracking disabled"
+                
+                MobileCore.setAdvertisingIdentifier("")
+            }
+            print("Tracking authorization status is '\(trackingAuthorizationResultText)'.")
+        }
+    }
     
     var body: some View {
         ScrollView {
@@ -64,6 +146,42 @@ struct EdgeIdentityView: View {
                 }) {
                     Text("Remove Identities with test-namespace")
                 }.buttonStyle(CustomButtonStyle())
+            }.padding()
+
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Advertising Identifier:")
+                Button(action: {
+                    requestTrackingAuthorization()
+                }) {
+                    Text("Request Tracking Authorization")
+                }.buttonStyle(CustomButtonStyle())
+                Text(trackingAuthorizationResultText)
+                Text("\(adID?.uuidString ?? "")")
+                
+                HStack {
+                    Button(action: {
+                        MobileCore.setAdvertisingIdentifier(adIdText)
+                    }) {
+                        Text("Set AdId")
+                    }.buttonStyle(CustomButtonStyle())
+                    TextField("Enter Ad ID", text: $adIdText)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .fixedSize()
+                        .autocapitalization(.none)
+                }
+                
+                HStack {
+                    Button(action: {
+                        MobileCore.setAdvertisingIdentifier(nil)
+                    }) {
+                        Text("Set AdId as nil")
+                    }.buttonStyle(CustomButtonStyle())
+                    Button(action: {
+                        MobileCore.setAdvertisingIdentifier("00000000-0000-0000-0000-000000000000")
+                    }) {
+                        Text("Set AdId as zeros")
+                    }.buttonStyle(CustomButtonStyle())
+                }
             }.padding()
         }
         

--- a/Swift/AEPSampleApp/Info.plist
+++ b/Swift/AEPSampleApp/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>App would like to access IDFA for advertising tracking purposes</string>
 	<key>CFBundleIconFiles</key>
 	<array>
 		<string>Adobe_Experience_Platform_logo_256px.png</string>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This update to the Edge Identity view is to demonstrate the capabilities from the ad ID update and showcase a real implementation of IDFA in iOS using new extension capabilities. Pending test with Edge Identity extension release for ad ID changes.

Changes required for IDFA access in iOS:
Updated sample app framework to include `AppTrackingTransparency.framework`
Updated info.plist to include `NSUserTrackingUsageDescription`

