### PR TITLE
Standalone implementation required for retrieving IDFA value

### DIFF
--- a/Swift/AEPSampleApp.xcodeproj/project.pbxproj
+++ b/Swift/AEPSampleApp.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		3FEEA0E12523DBB5007EC317 /* CoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEEA0E02523DBB4007EC317 /* CoreView.swift */; };
 		3FEEA0E32524DA4A007EC317 /* ButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEEA0E22524DA4A007EC317 /* ButtonStyle.swift */; };
 		411747AC27ACB1DE0025F55A /* Adobe_Experience_Platform_logo_256px.png in Resources */ = {isa = PBXBuildFile; fileRef = 411747AB27ACB1DE0025F55A /* Adobe_Experience_Platform_logo_256px.png */; };
+		4C7869AE281356EF00858CEE /* AdIdUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7869AD281356EF00858CEE /* AdIdUtils.swift */; };
 		782B982124D9BA89009C5902 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782B982024D9BA89009C5902 /* AppDelegate.swift */; };
 		782B982324D9BA89009C5902 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782B982224D9BA89009C5902 /* SceneDelegate.swift */; };
 		782B982A24D9BA8C009C5902 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 782B982924D9BA8C009C5902 /* Assets.xcassets */; };
@@ -48,6 +49,7 @@
 		3FEEA0E02523DBB4007EC317 /* CoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreView.swift; sourceTree = "<group>"; };
 		3FEEA0E22524DA4A007EC317 /* ButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonStyle.swift; sourceTree = "<group>"; };
 		411747AB27ACB1DE0025F55A /* Adobe_Experience_Platform_logo_256px.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Adobe_Experience_Platform_logo_256px.png; path = ../../Resources/Icons/Adobe_Experience_Platform_logo_256px.png; sourceTree = "<group>"; };
+		4C7869AD281356EF00858CEE /* AdIdUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdIdUtils.swift; sourceTree = "<group>"; };
 		782B981D24D9BA89009C5902 /* AEPSampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AEPSampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		782B982024D9BA89009C5902 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		782B982224D9BA89009C5902 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -115,6 +117,7 @@
 				782B982024D9BA89009C5902 /* AppDelegate.swift */,
 				218306EC26138BBA00889569 /* MenuView.swift */,
 				782B982224D9BA89009C5902 /* SceneDelegate.swift */,
+				4C7869AD281356EF00858CEE /* AdIdUtils.swift */,
 				3FEEA0E02523DBB4007EC317 /* CoreView.swift */,
 				7876121024DC601B001CABB5 /* AssuranceView.swift */,
 				D42BE5C22524569C00782C3C /* EdgeView.swift */,
@@ -311,6 +314,7 @@
 				782B982124D9BA89009C5902 /* AppDelegate.swift in Sources */,
 				782B982324D9BA89009C5902 /* SceneDelegate.swift in Sources */,
 				3FEEA0E12523DBB5007EC317 /* CoreView.swift in Sources */,
+				4C7869AE281356EF00858CEE /* AdIdUtils.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Swift/AEPSampleApp/AdIdUtils.swift
+++ b/Swift/AEPSampleApp/AdIdUtils.swift
@@ -32,7 +32,7 @@ class AdIdUtils {
         return ASIdentifierManager.shared().advertisingIdentifier
     }
     
-    /// Checks if ad ID tracking authorization is provided, if not returns `false`. Handles both iOS 14+ and <= iOS 13,
+    /// Checks if ad ID tracking authorization is provided, if not returns `false`. Handles both iOS 14+ and iOS < 14,
     /// using the appropriate APIs for each case
     ///
     /// - Returns: `true` if authorized, `false` for any other state
@@ -41,7 +41,7 @@ class AdIdUtils {
             print("Tracking authorization status: \(ATTrackingManager.trackingAuthorizationStatus)")
             return ATTrackingManager.trackingAuthorizationStatus == .authorized
         } else {
-            print("iOS version <= 13 detected; using ASIdentifierManager and getting IDFA directly.")
+            print("iOS version < 14 detected; using ASIdentifierManager and getting IDFA directly.")
             print("Tracking authorization status: \(ASIdentifierManager.shared().isAdvertisingTrackingEnabled)")
             return ASIdentifierManager.shared().isAdvertisingTrackingEnabled
         }
@@ -56,8 +56,6 @@ class AdIdUtils {
             print("Calling requestTrackingAuthorization. Dialog will only be shown once per app install.")
             ATTrackingManager.requestTrackingAuthorization { status in
                 print("Request tracking authorization status is '\(status)'.")
-                let adID = getAdvertisingIdentifierForEnvironment()
-                print("Advertising identifier: \(adID)")
                 switch status {
                 // Tracking authorization dialog was shown and authorization given
                 case .authorized:
@@ -79,14 +77,8 @@ class AdIdUtils {
                 callbackHandler()
             }
         } else {
-            isTrackingAuthorized()
-            if ASIdentifierManager.shared().isAdvertisingTrackingEnabled {
-                // Tracking authorized; IDFA now accessible
-                getAdvertisingIdentifierForEnvironment()
-            } else {
-                // Tracking not authorized; IDFA is all-zeros
-                getAdvertisingIdentifierForEnvironment()
-            }
+            // iOS version < 14 does not use ad ID tracking authorization; see Apple guidance on using
+            // advertisingIdentifier: https://developer.apple.com/documentation/adsupport/asidentifiermanager/1614151-advertisingidentifier
             callbackHandler()
         }
     }

--- a/Swift/AEPSampleApp/AdIdUtils.swift
+++ b/Swift/AEPSampleApp/AdIdUtils.swift
@@ -1,0 +1,83 @@
+/*
+ Copyright 2022 Adobe
+ All Rights Reserved.
+ 
+ NOTICE: Adobe permits you to use, modify, and distribute this file in
+ accordance with the terms of the Adobe license agreement accompanying
+ it.
+ */
+
+import AdSupport
+import AppTrackingTransparency
+import Foundation
+
+class AdIdUtils {
+    
+    /// Provides the `advertisingIdentifier` for the given environment, assuming tracking authorization is provided
+    ///
+    /// Simulators will never provide a valid UUID, regardless of authorization; use the set ad ID flow to test a specific ad ID.
+    static func getAdvertisingIdentifierForEnvironment() -> UUID {
+        #if targetEnvironment(simulator)
+        print("""
+            Simulator environment detected. Please note that simulators cannot retrieve valid advertising identifier
+            from the ASIdentifierManager (as specified by Apple); an all-zeros UUID will be retrieved even if
+            authorization is provided. If you want to use a specific ad ID, you can use the set ad ID flow.
+            """)
+        #endif
+        print("Advertising identifier: \(ASIdentifierManager.shared().advertisingIdentifier)")
+        return ASIdentifierManager.shared().advertisingIdentifier
+    }
+    
+    /// Requests tracking authorization from the user; prompt will only be shown once per app install, as per Apple rules
+    ///
+    /// It is possible to change tracking permissions at the Settings app level. Any change in tracking permissions will terminate the app.
+    /// It is also possible for system-wide tracking to be off but individual per-app permissions granted.
+    /// If "Allow Apps to Request to Track" at the system level was on and is turned off, a system prompt appears asking if previously provided individual per-app tracking permissions should be kept as-is or all turned off
+    static func requestTrackingAuthorization() {
+        // ATTrackingManager only available in iOS 14+
+        // Requires Xcode 12 and AppTrackingTransparency framework
+        if #available(iOS 14, *) {
+            print("Calling requestTrackingAuthorization. Dialog will only be shown once per app install.")
+            ATTrackingManager.requestTrackingAuthorization { status in
+                print("Request tracking authorization status is '\(status)'.")
+                let adID = getAdvertisingIdentifierForEnvironment()
+                print("Advertising identifier: \(adID)")
+                switch status {
+                // Tracking authorization dialog was shown and authorization given
+                case .authorized:
+                    // IDFA now accessible
+                    print("\(status)")
+                // For all cases below (that is, not .authorized), IDFA is all-zeros
+                // Tracking authorization dialog was shown and permission is denied
+                case .denied:
+                    print("\(status)")
+                // Tracking authorization dialog has not been shown
+                case .notDetermined:
+                    print("\(status)")
+                // Tracking authorization dialog is not allowed to be shown
+                case .restricted:
+                    print("\(status)")
+                @unknown default:
+                    print("\(status)")
+                }
+            }
+        } else {
+            // ASIdentifierManager used for iOS <= 13
+            print("""
+                  iOS version <= 13 detected. ATTrackingManager's requestTrackingAuthorization is not available; using ASIdentifierManager and getting IDFA directly.
+                  ASIdentifierManager.shared().isAdvertisingTrackingEnabled: \(ASIdentifierManager.shared().isAdvertisingTrackingEnabled)
+                  Advertising identifier: \(getAdvertisingIdentifierForEnvironment())
+                  """)
+            print("Tracking authorization status is '\(ASIdentifierManager.shared().isAdvertisingTrackingEnabled)'.")
+            if ASIdentifierManager.shared().isAdvertisingTrackingEnabled {
+                // IDFA now accessible
+                let adID = getAdvertisingIdentifierForEnvironment()
+                print("Advertising identifier: \(adID)")
+            } else {
+                // IDFA is all-zeros
+                let adID = getAdvertisingIdentifierForEnvironment()
+                print("Advertising identifier: \(adID)")
+            }
+        }
+    }
+}

--- a/Swift/AEPSampleApp/AdIdUtils.swift
+++ b/Swift/AEPSampleApp/AdIdUtils.swift
@@ -13,15 +13,19 @@ import Foundation
 
 class AdIdUtils {
     
-    /// Provides the `advertisingIdentifier` for the given environment, assuming tracking authorization is provided
+    /// Provides the `advertisingIdentifier` for the given environment, assuming tracking authorization is provided.
+    /// Use ``requestTrackingAuthorization(callbackHandler:)`` to request authorization.
     ///
-    /// Simulators will never provide a valid UUID, regardless of authorization; use the set ad ID flow to test a specific ad ID.
+    /// Simulators may not provide a valid `UUID`, regardless of authorization state; in this case, use the set ad ID flow to test a specific
+    /// ad ID instead. Please see Apple's documentation on `advertisingIdentifier` for more details:
+    /// https://developer.apple.com/documentation/adsupport/asidentifiermanager/1614151-advertisingidentifier
+    ///
+    /// - Returns: The IDFA in `UUID` format; all-zeros if tracking is not authorized or in simulator environment
     static func getAdvertisingIdentifierForEnvironment() -> UUID {
         #if targetEnvironment(simulator)
         print("""
-            Simulator environment detected. Please note that simulators cannot retrieve valid advertising identifier
-            from the ASIdentifierManager (as specified by Apple); an all-zeros UUID will be retrieved even if
-            authorization is provided. If you want to use a specific ad ID, you can use the set ad ID flow.
+            Simulator environment detected; an all-zeros UUID will be retrieved even if
+            authorization is provided. Use the set ad ID flow to set a specific ad ID value.
             """)
         #endif
         print("Advertising identifier: \(ASIdentifierManager.shared().advertisingIdentifier)")
@@ -34,30 +38,20 @@ class AdIdUtils {
     /// - Returns: `true` if authorized, `false` for any other state
     static func isTrackingAuthorized() -> Bool {
         if #available(iOS 14, *) {
-            print("ATTrackingManager.trackingAuthorizationStatus: \(ATTrackingManager.trackingAuthorizationStatus)")
+            print("Tracking authorization status: \(ATTrackingManager.trackingAuthorizationStatus)")
             return ATTrackingManager.trackingAuthorizationStatus == .authorized
         } else {
-            // ASIdentifierManager used for iOS <= 13
-            print("""
-                  iOS version <= 13 detected. ATTrackingManager's requestTrackingAuthorization is not available; using ASIdentifierManager and getting IDFA directly.
-                  ASIdentifierManager.shared().isAdvertisingTrackingEnabled: \(ASIdentifierManager.shared().isAdvertisingTrackingEnabled)
-                  Advertising identifier: \(getAdvertisingIdentifierForEnvironment())
-                  """)
-            print("Tracking authorization status is '\(ASIdentifierManager.shared().isAdvertisingTrackingEnabled)'.")
+            print("iOS version <= 13 detected; using ASIdentifierManager and getting IDFA directly.")
+            print("Tracking authorization status: \(ASIdentifierManager.shared().isAdvertisingTrackingEnabled)")
             return ASIdentifierManager.shared().isAdvertisingTrackingEnabled
         }
     }
     
     /// Requests tracking authorization from the user; prompt will only be shown once per app install, as per Apple rules
     ///
-    /// It is possible to change tracking permissions at the Settings app level. Any change in tracking permissions will terminate the app.
-    /// It is also possible for system-wide tracking to be off but individual per-app permissions granted.
-    /// If "Allow Apps to Request to Track" at the system level was on and is turned off, a system prompt appears asking if previously provided individual per-app tracking permissions should be kept as-is or all turned off
-    /// Note that if another system prompt is already showing, the dialog with not show and auth status will be .notDetermined
-    /// Also the app needs some startup time before trying to show the prompt; otherwise if it's not ready when you call the request, auth status will be .notDetermined
+    /// - Parameters:
+    ///     - callbackHandler: Called after authorization flow completes, to allow for request chaining
     static func requestTrackingAuthorization(callbackHandler: @escaping ()->() = {}) {
-        // ATTrackingManager only available in iOS 14+
-        // Requires Xcode 12 and AppTrackingTransparency framework
         if #available(iOS 14, *) {
             print("Calling requestTrackingAuthorization. Dialog will only be shown once per app install.")
             ATTrackingManager.requestTrackingAuthorization { status in
@@ -68,38 +62,32 @@ class AdIdUtils {
                 // Tracking authorization dialog was shown and authorization given
                 case .authorized:
                     // IDFA now accessible
-                    print("\(status)")
+                    print("Authorization status: \(status)")
                 // For all cases below (that is, not .authorized), IDFA is all-zeros
                 // Tracking authorization dialog was shown and permission is denied
                 case .denied:
-                    print("\(status)")
+                    print("Authorization status: \(status)")
                 // Tracking authorization dialog has not been shown
                 case .notDetermined:
-                    print("\(status)")
-                // Tracking authorization dialog is not allowed to be shown
+                    print("Authorization status: \(status)")
+                // Tracking authorization dialog is not allowed to be shown; not controlled by the user
                 case .restricted:
-                    print("\(status)")
+                    print("Authorization status: \(status)")
                 @unknown default:
-                    print("\(status)")
+                    print("Authorization status: \(status)")
                 }
+                callbackHandler()
             }
         } else {
-            // ASIdentifierManager used for iOS <= 13
-            print("""
-                  iOS version <= 13 detected. ATTrackingManager's requestTrackingAuthorization is not available; using ASIdentifierManager and getting IDFA directly.
-                  ASIdentifierManager.shared().isAdvertisingTrackingEnabled: \(ASIdentifierManager.shared().isAdvertisingTrackingEnabled)
-                  Advertising identifier: \(getAdvertisingIdentifierForEnvironment())
-                  """)
-            print("Tracking authorization status is '\(ASIdentifierManager.shared().isAdvertisingTrackingEnabled)'.")
+            isTrackingAuthorized()
             if ASIdentifierManager.shared().isAdvertisingTrackingEnabled {
-                // IDFA now accessible
-                let adID = getAdvertisingIdentifierForEnvironment()
-                print("Advertising identifier: \(adID)")
+                // Tracking authorized; IDFA now accessible
+                getAdvertisingIdentifierForEnvironment()
             } else {
-                // IDFA is all-zeros
-                let adID = getAdvertisingIdentifierForEnvironment()
-                print("Advertising identifier: \(adID)")
+                // Tracking not authorized; IDFA is all-zeros
+                getAdvertisingIdentifierForEnvironment()
             }
+            callbackHandler()
         }
     }
 }

--- a/Swift/AEPSampleApp/AppDelegate.swift
+++ b/Swift/AEPSampleApp/AppDelegate.swift
@@ -42,7 +42,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     private let LAUNCH_ENVIRONMENT_FILE_ID = ""
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-
+        
         // step-init-start
         MobileCore.setLogLevel(.trace)
         let appState = application.applicationState;
@@ -53,9 +53,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                           Edge.self,
                           Consent.self,
                           AEPEdgeIdentity.Identity.self
-                          //step-extension-start
+                          // step-extension-start
                           , SampleExtension.self
-                          //step-extension-end
+                          // step-extension-end
                           , UserProfile.self
                           // step-assurance-start
                           , Assurance.self
@@ -76,10 +76,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         // step-init-end
         
         // register push notification
-        registerForPushNotifications(application: application)
+        registerForPushNotifications(application: application) {
+            DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 1) {
+                AdIdUtils.requestTrackingAuthorization()
+            }
+        }
         
-        // Request ad ID tracking permissions
-        AdIdUtils.requestTrackingAuthorization()
         return true
     }
 
@@ -98,45 +100,52 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
     
     // MARK: Registeration for push notification
-    func registerForPushNotifications(application: UIApplication) {
-          let center = UNUserNotificationCenter.current()
-          center.requestAuthorization(options: [.badge, .sound, .alert]) {
+    
+    /// Requests permissions for remote notifications for the application, and calls the completion handler when the operation is complete in order to allow for request chaining (completion handler is called regardless of authorization status given)
+    ///
+    /// - Parameters:
+    ///     - application: the application instance that notifications will be registered to
+    ///     - completionHandler: called when the registration process is completed, regardless of permissions granted; allows of chaining of requests
+    func registerForPushNotifications(application: UIApplication, completionHandler: @escaping ()->() = {}) {
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.badge, .sound, .alert]) {
             [weak self] granted, _ in
+            defer { completionHandler() }
             guard granted else { return }
-
+            
             center.delegate = self
-
+            
             DispatchQueue.main.async {
-              application.registerForRemoteNotifications()
+                application.registerForRemoteNotifications()
             }
-          }
         }
-
-        func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-            let tokenParts = deviceToken.map { data in String(format: "%02.2hhx", data) }
-            let token = tokenParts.joined()
-            print("Device Token: \(token)")
-
-            // Send push token to experience platform
-            MobileCore.setPushIdentifier(deviceToken)
+    }
+    
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        let tokenParts = deviceToken.map { data in String(format: "%02.2hhx", data) }
+        let token = tokenParts.joined()
+        print("Device Token: \(token)")
+        
+        // Send push token to experience platform
+        MobileCore.setPushIdentifier(deviceToken)
+    }
+    
+    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        print("Failed to register: \(error)")
+    }
+    
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler:
+        @escaping (UNNotificationPresentationOptions) -> Void) {
+            
+            completionHandler([.alert, .sound, .badge])
         }
-
-        func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
-          print("Failed to register: \(error)")
-        }
-
-        func userNotificationCenter(
-          _ center: UNUserNotificationCenter,
-          willPresent notification: UNNotification,
-          withCompletionHandler completionHandler:
-          @escaping (UNNotificationPresentationOptions) -> Void) {
-
-          completionHandler([.alert, .sound, .badge])
-        }
-
-        func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-            Messaging.handleNotificationResponse(response, applicationOpened: true, customActionId: nil)
-            completionHandler()
-        }
+    
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        Messaging.handleNotificationResponse(response, applicationOpened: true, customActionId: nil)
+        completionHandler()
+    }
 }
 

--- a/Swift/AEPSampleApp/AppDelegate.swift
+++ b/Swift/AEPSampleApp/AppDelegate.swift
@@ -78,6 +78,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         // register push notification
         registerForPushNotifications(application: application)
         
+        // Request ad ID tracking permissions
+        AdIdUtils.requestTrackingAuthorization()
         return true
     }
 

--- a/Swift/AEPSampleApp/EdgeIdentityView.swift
+++ b/Swift/AEPSampleApp/EdgeIdentityView.swift
@@ -65,7 +65,6 @@ struct EdgeIdentityView: View {
                 }.buttonStyle(CustomButtonStyle())
             }.padding()
         }
-        
     }
 }
 

--- a/Swift/AEPSampleApp/EdgeIdentityView.swift
+++ b/Swift/AEPSampleApp/EdgeIdentityView.swift
@@ -37,7 +37,6 @@ struct EdgeIdentityView: View {
                             Text("Copy")
                             }
                         }
-                
                 Button(action: {
                     Identity.getIdentities { identityMap, error in
                         currentIdentityMap = identityMap

--- a/Swift/AEPSampleApp/Info.plist
+++ b/Swift/AEPSampleApp/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>App would like to access IDFA for advertising tracking purposes</string>
 	<key>CFBundleIconFiles</key>
 	<array>
 		<string>Adobe_Experience_Platform_logo_256px.png</string>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is a minimal standalone implementation for retrieving the IDFA value from iOS, handling both methods of fetching IDFA (pre iOS 14 and iOS 14+). It uses a utils class with static methods for ad ID related functionality, leveraging APIs provided by Apple ad ID frameworks:
AdSupport for iOS <= 13
AppTrackingTransparency for iOS 14+

The required Info.plist key for enabling ad ID usage is also included:
Privacy - Tracking Usage Description

Currently the request to track is called in the AppDelegate startup flow, but it can be called from anywhere if an alternate flow is desired.

## Related Issue

This is related to Jira ticket: [AMSDK-11664 (iOS) Update sample app for ad ID consent testing](https://jira.corp.adobe.com/browse/AMSDK-11664)
Where the ad ID feature was split into an independent IDFA implementation PR and Edge Identity ad ID update PR

## Motivation and Context

This implementation provides an easy to follow example for how to fetch the IDFA value following Apple guidelines. It is distinct from any dependencies on a specific AEP extension (that is, ad ID implementation for Edge Identity). It is also closer to a real-world implementation of ad ID tracking as opposed to having the functionality tied to a test button from ad ID functionality from Edge Identity.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using simulator iPod touch - 7th generation - iOS 15.4, with a fresh install of the test app instance (Apple only allows an app to show the ad ID tracking permission dialog once per app install); the positive and negative cases each a couple times, verifying the console output of the results match the selected option.

## Screenshots (if appropriate):
![Screen Shot 2022-04-22 at 3 00 05 PM](https://user-images.githubusercontent.com/95260439/164801404-e6815f13-70af-4ca3-944f-cc5a0a9bd718.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
