### PR TITLE
Replace use of deprecated XDMFormatters class

### DIFF
--- a/Swift/AEPSampleApp/xdmlib/MobileSDKCommerceSchema.swift
+++ b/Swift/AEPSampleApp/xdmlib/MobileSDKCommerceSchema.swift
@@ -54,6 +54,6 @@ extension MobileSDKCommerceSchema {
 		if let unwrapped = eventMergeId { try container.encode(unwrapped, forKey: .eventMergeId) }
 		if let unwrapped = eventType { try container.encode(unwrapped, forKey: .eventType) }
 		if let unwrapped = productListItems { try container.encode(unwrapped, forKey: .productListItems) }
-        if let unwrapped = timestamp?.getISO8601UTCDateWithMilliseconds() { try container.encode(unwrapped, forKey: .timestamp) }
+		if let unwrapped = timestamp?.getISO8601UTCDateWithMilliseconds() { try container.encode(unwrapped, forKey: .timestamp) }
 	}
 }

--- a/Swift/AEPSampleApp/xdmlib/MobileSDKCommerceSchema.swift
+++ b/Swift/AEPSampleApp/xdmlib/MobileSDKCommerceSchema.swift
@@ -54,6 +54,6 @@ extension MobileSDKCommerceSchema {
 		if let unwrapped = eventMergeId { try container.encode(unwrapped, forKey: .eventMergeId) }
 		if let unwrapped = eventType { try container.encode(unwrapped, forKey: .eventType) }
 		if let unwrapped = productListItems { try container.encode(unwrapped, forKey: .productListItems) }
-		if let unwrapped = XDMFormatters.dateToISO8601String(from: timestamp) { try container.encode(unwrapped, forKey: .timestamp) }
+        if let unwrapped = timestamp?.getISO8601UTCDateWithMilliseconds() { try container.encode(unwrapped, forKey: .timestamp) }
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The XDMFormatters class in the AEPEdge extension is deprecated and will be removed in version 2.0.0. Replace use with getISO8601UTCDateWithMilliseconds() in Date class extension from AEPServices module.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
